### PR TITLE
Fixing index collector issue

### DIFF
--- a/export_index.js
+++ b/export_index.js
@@ -38,16 +38,19 @@ dbs.forEach(function(dbName) {
     // Switch to this database
     var currentDb = mongoDb.getSiblingDB(dbName);
     
-    // Get all collections (excluding system collections)
-    var collections = currentDb.getCollectionNames()
-        .filter(function(c) {
-            return !c.startsWith("system.");
+    // Get all collections (excluding system collections and views)
+    var collections = currentDb.getCollectionInfos()
+        .filter(function(info) {
+            return info.type === "collection" && !info.name.startsWith("system.");
+        })
+        .map(function(info) {
+            return info.name;
         });
     
     // Process each collection
     collections.forEach(function(collName) {
         // Get indexes for this collection
-        var indexes = currentDb[collName].getIndexes();
+        var indexes = currentDb.getCollection(collName).getIndexes();
         
         if (indexes.length === 0) {
             return;


### PR DESCRIPTION
This pull request refines how collections are identified and filtered in `export_index.js` to improve accuracy and reliability, especially in environments where views or non-collection types might be present.

**Collection filtering improvements:**

* Changed from using `getCollectionNames()` to `getCollectionInfos()` to retrieve detailed collection metadata, ensuring only actual collections (not views or other types) are included and system collections are excluded.
* Updated the way collections are accessed by switching to `currentDb.getCollection(collName)` for more robust and explicit collection references.